### PR TITLE
Fix "ambiguous overload" compiler warnings

### DIFF
--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java
@@ -39,7 +39,7 @@ public abstract class BinaryConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<byte[]> deserializeCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(Base64Reader);
+		return reader.deserializeCollectionCustom(Base64Reader);
 	}
 
 	public static void deserializeCollection(final JsonReader reader, final Collection<byte[]> res) throws IOException {
@@ -48,7 +48,7 @@ public abstract class BinaryConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<byte[]> deserializeNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(Base64Reader);
+		return reader.deserializeNullableCollectionCustom(Base64Reader);
 	}
 
 	public static void deserializeNullableCollection(final JsonReader reader, final Collection<byte[]> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java
@@ -110,7 +110,7 @@ public abstract class BoolConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Boolean> deserializeCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(READER);
+		return reader.deserializeCollectionCustom(READER);
 	}
 
 	public static void deserializeCollection(final JsonReader reader, final Collection<Boolean> res) throws IOException {
@@ -119,7 +119,7 @@ public abstract class BoolConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Boolean> deserializeNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(READER);
+		return reader.deserializeNullableCollectionCustom(READER);
 	}
 
 	public static void deserializeNullableCollection(final JsonReader reader, final Collection<Boolean> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java
@@ -1655,7 +1655,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 					}
 					final JsonReader.ReadObject<?> contentReader = tryFindReader(content);
 					if (contentReader != null) {
-						final ArrayList<?> result = json.deserializeNullableCollection(contentReader);
+						final ArrayList<?> result = json.deserializeNullableCollectionCustom(contentReader);
 						if (container.isArray()) {
 							return returnAsArray(content, result);
 						}
@@ -1675,7 +1675,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 			}
 			final JsonReader.ReadObject<?> contentReader = tryFindReader(content);
 			if (contentReader != null) {
-				final ArrayList<?> result = json.deserializeNullableCollection(contentReader);
+				final ArrayList<?> result = json.deserializeNullableCollectionCustom(contentReader);
 				return returnAsArray(content, result);
 			}
 		}
@@ -1770,7 +1770,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 			}
 			final JsonReader.ReadObject<?> simpleReader = tryFindReader(manifest);
 			if (simpleReader != null) {
-				return json.deserializeNullableCollection(simpleReader);
+				return json.deserializeNullableCollectionCustom(simpleReader);
 			}
 			if (fallback != null) {
 				final Object array = Array.newInstance(manifest, 0);
@@ -1885,7 +1885,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 		}
 		final JsonReader.ReadObject simpleReader = tryFindReader(manifest);
 		if (simpleReader != null) {
-			return json.deserializeNullableCollection(simpleReader);
+			return json.deserializeNullableCollectionCustom(simpleReader);
 		}
 		if (fallback != null) {
 			final Object array = Array.newInstance(manifest, 0);
@@ -2011,7 +2011,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 			}
 			final JsonReader.ReadObject<?> simpleElementReader = tryFindReader(elementManifest);
 			if (simpleElementReader != null) {
-				List<?> list = json.deserializeNullableCollection(simpleElementReader);
+				List<?> list = json.deserializeNullableCollectionCustom(simpleElementReader);
 				return (TResult) convertResultToArray(elementManifest, list);
 			}
 		}
@@ -2269,7 +2269,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 		}
 		final JsonReader.ReadObject<?> simpleReader = tryFindReader(manifest);
 		if (simpleReader != null) {
-			return json.iterateOver(simpleReader);
+			return json.iterateOverCustom(simpleReader);
 		}
 		if (fallback != null) {
 			final Object array = Array.newInstance(manifest, 0);

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java
@@ -1594,7 +1594,7 @@ public final class JsonReader<TContext> {
 		return res.toArray(emptyArray);
 	}
 
-	public final <T, S extends T> ArrayList<T> deserializeCollection(final ReadObject<S> readObject) throws IOException {
+	public final <T, S extends T> ArrayList<T> deserializeCollectionCustom(final ReadObject<S> readObject) throws IOException {
 		final ArrayList<T> res = new ArrayList<T>(4);
 		deserializeCollection(readObject, res);
 		return res;
@@ -1609,7 +1609,7 @@ public final class JsonReader<TContext> {
 		checkArrayEnd();
 	}
 
-	public final <T, S extends T> ArrayList<T> deserializeNullableCollection(final ReadObject<S> readObject) throws IOException {
+	public final <T, S extends T> ArrayList<T> deserializeNullableCollectionCustom(final ReadObject<S> readObject) throws IOException {
 		final ArrayList<T> res = new ArrayList<T>(4);
 		deserializeNullableCollection(readObject, res);
 		return res;
@@ -1676,7 +1676,7 @@ public final class JsonReader<TContext> {
 		checkArrayEnd();
 	}
 
-	public final <T> Iterator<T> iterateOver(final JsonReader.ReadObject<T> reader) {
+	public final <T> Iterator<T> iterateOverCustom(final JsonReader.ReadObject<T> reader) {
 		return new WithReader<T>(reader, this);
 	}
 

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java
@@ -70,7 +70,7 @@ public abstract class MapConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Map<String, String>> deserializeCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(TypedMapReader);
+		return reader.deserializeCollectionCustom(TypedMapReader);
 	}
 
 	public static void deserializeCollection(final JsonReader reader, final Collection<Map<String, String>> res) throws IOException {
@@ -79,7 +79,7 @@ public abstract class MapConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Map<String, String>> deserializeNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(TypedMapReader);
+		return reader.deserializeNullableCollectionCustom(TypedMapReader);
 	}
 
 	public static void deserializeNullableCollection(final JsonReader reader, final Collection<Map<String, String>> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java
@@ -56,7 +56,7 @@ public abstract class NetConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<URI> deserializeUriCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(UriReader);
+		return reader.deserializeCollectionCustom(UriReader);
 	}
 
 	public static void deserializeUriCollection(final JsonReader reader, final Collection<URI> res) throws IOException {
@@ -65,7 +65,7 @@ public abstract class NetConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<URI> deserializeUriNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(UriReader);
+		return reader.deserializeNullableCollectionCustom(UriReader);
 	}
 
 	public static void deserializeUriNullableCollection(final JsonReader reader, final Collection<URI> res) throws IOException {
@@ -92,7 +92,7 @@ public abstract class NetConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<InetAddress> deserializeIpCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(AddressReader);
+		return reader.deserializeCollectionCustom(AddressReader);
 	}
 
 	public static void deserializeIpCollection(final JsonReader reader, final Collection<InetAddress> res) throws IOException {
@@ -101,7 +101,7 @@ public abstract class NetConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<InetAddress> deserializeIpNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(AddressReader);
+		return reader.deserializeNullableCollectionCustom(AddressReader);
 	}
 
 	public static void deserializeIpNullableCollection(final JsonReader reader, final Collection<InetAddress> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java
@@ -570,7 +570,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Double> deserializeDoubleCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(DOUBLE_READER);
+		return reader.deserializeCollectionCustom(DOUBLE_READER);
 	}
 
 	public static void deserializeDoubleCollection(final JsonReader reader, final Collection<Double> res) throws IOException {
@@ -579,7 +579,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Double> deserializeDoubleNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(DOUBLE_READER);
+		return reader.deserializeNullableCollectionCustom(DOUBLE_READER);
 	}
 
 	public static void deserializeDoubleNullableCollection(final JsonReader reader, final Collection<Double> res) throws IOException {
@@ -772,7 +772,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Float> deserializeFloatCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(FLOAT_READER);
+		return reader.deserializeCollectionCustom(FLOAT_READER);
 	}
 
 	public static void deserializeFloatCollection(final JsonReader reader, Collection<Float> res) throws IOException {
@@ -781,7 +781,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Float> deserializeFloatNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(FLOAT_READER);
+		return reader.deserializeNullableCollectionCustom(FLOAT_READER);
 	}
 
 	public static void deserializeFloatNullableCollection(final JsonReader reader, final Collection<Float> res) throws IOException {
@@ -981,7 +981,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Integer> deserializeIntCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(INT_READER);
+		return reader.deserializeCollectionCustom(INT_READER);
 	}
 
 	public static int[] deserializeIntArray(final JsonReader reader) throws IOException {
@@ -1080,7 +1080,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Short> deserializeShortNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(SHORT_READER);
+		return reader.deserializeNullableCollectionCustom(SHORT_READER);
 	}
 
 	public static void deserializeShortNullableCollection(final JsonReader reader, final Collection<Short> res) throws IOException {
@@ -1093,7 +1093,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Integer> deserializeIntNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(INT_READER);
+		return reader.deserializeNullableCollectionCustom(INT_READER);
 	}
 
 	public static void deserializeIntNullableCollection(final JsonReader reader, final Collection<Integer> res) throws IOException {
@@ -1317,7 +1317,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Long> deserializeLongCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(LONG_READER);
+		return reader.deserializeCollectionCustom(LONG_READER);
 	}
 
 	public static void deserializeLongCollection(final JsonReader reader, final Collection<Long> res) throws IOException {
@@ -1326,7 +1326,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Long> deserializeLongNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(LONG_READER);
+		return reader.deserializeNullableCollectionCustom(LONG_READER);
 	}
 
 	public static void deserializeLongNullableCollection(final JsonReader reader, final Collection<Long> res) throws IOException {
@@ -1682,7 +1682,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<BigDecimal> deserializeDecimalCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(DecimalReader);
+		return reader.deserializeCollectionCustom(DecimalReader);
 	}
 
 	public static void deserializeDecimalCollection(final JsonReader reader, final Collection<BigDecimal> res) throws IOException {
@@ -1691,7 +1691,7 @@ public abstract class NumberConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<BigDecimal> deserializeDecimalNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(DecimalReader);
+		return reader.deserializeNullableCollectionCustom(DecimalReader);
 	}
 
 	public static void deserializeDecimalNullableCollection(final JsonReader reader, final Collection<BigDecimal> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java
@@ -117,7 +117,7 @@ public abstract class ObjectConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Map<String, Object>> deserializeMapCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(TypedMapReader);
+		return reader.deserializeCollectionCustom(TypedMapReader);
 	}
 
 	public static void deserializeMapCollection(final JsonReader reader, final Collection<Map<String, Object>> res) throws IOException {
@@ -126,7 +126,7 @@ public abstract class ObjectConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Map<String, Object>> deserializeNullableMapCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(TypedMapReader);
+		return reader.deserializeNullableCollectionCustom(TypedMapReader);
 	}
 
 	public static void deserializeNullableMapCollection(final JsonReader reader, final Collection<Map<String, Object>> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java
@@ -89,7 +89,7 @@ public abstract class StringConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<String> deserializeCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(READER);
+		return reader.deserializeCollectionCustom(READER);
 	}
 
 	public static void deserializeCollection(final JsonReader reader, final Collection<String> res) throws IOException {
@@ -98,7 +98,7 @@ public abstract class StringConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<String> deserializeNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(READER);
+		return reader.deserializeNullableCollectionCustom(READER);
 	}
 
 	public static void deserializeNullableCollection(final JsonReader reader, final Collection<String> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java
@@ -180,7 +180,7 @@ public abstract class UUIDConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<UUID> deserializeCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(READER);
+		return reader.deserializeCollectionCustom(READER);
 	}
 
 	public static void deserializeCollection(final JsonReader reader, final Collection<UUID> res) throws IOException {
@@ -189,7 +189,7 @@ public abstract class UUIDConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<UUID> deserializeNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(READER);
+		return reader.deserializeNullableCollectionCustom(READER);
 	}
 
 	public static void deserializeNullableCollection(final JsonReader reader, final Collection<UUID> res) throws IOException {

--- a/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java
+++ b/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java
@@ -199,7 +199,7 @@ public abstract class XmlConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Element> deserializeCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeCollection(Reader);
+		return reader.deserializeCollectionCustom(Reader);
 	}
 
 	public static void deserializeCollection(final JsonReader reader, final Collection<Element> res) throws IOException {
@@ -208,7 +208,7 @@ public abstract class XmlConverter {
 
 	@SuppressWarnings("unchecked")
 	public static ArrayList<Element> deserializeNullableCollection(final JsonReader reader) throws IOException {
-		return reader.deserializeNullableCollection(Reader);
+		return reader.deserializeNullableCollectionCustom(Reader);
 	}
 
 	public static void deserializeNullableCollection(final JsonReader reader, final Collection<Element> res) throws IOException {


### PR DESCRIPTION
Renamed some of the `ReadObject` method variants to avoid "ambiguous overload" compiler warnings